### PR TITLE
ci(e2e-nightly-34x): run on `Agoric` branch, not `v0.34.x`

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -26,8 +26,9 @@ jobs:
           go-version: '1.19'
 
       - uses: actions/checkout@v3
-        with:
-          ref: 'v0.34.x'
+# AGORIC: We don't maintain a v0.34.x branch yet, so default will do.
+#        with:
+#          ref: 'v0.34.x'
 
       - name: Build
         working-directory: test/e2e

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
 # instead of spending time compiling them.
-FROM golang:1.19
+FROM golang:1.19-bullseye
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev librocksdb-dev >/dev/null


### PR DESCRIPTION
## Description

`agoric-labs/cometbft` does not maintain a `v0.34.x` branch, instead we set our default branch to be `Agoric`.  So we want the nightly tests to run against `Agoric`.  Make it so.

The other change is to pin the docker image `golang:1.19-bullseye` since `golang:1.19` now means `golang:1.19-bookworm` which broke RocksDB support.

<!--
_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

