### PR TITLE
ci(e2e-nightly-34x): don't create Slack message on success

### DIFF
--- a/.github/workflows/e2e-nightly-34x.yml
+++ b/.github/workflows/e2e-nightly-34x.yml
@@ -62,7 +62,9 @@ jobs:
 
   e2e-nightly-success:   # may turn this off once they seem to pass consistently
     needs: e2e-nightly-test
-    if: ${{ success() }}
+# AGORIC: disabled because they pass consistently
+    if: ${{ false }}
+#    if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack on success


### PR DESCRIPTION
## Description

Silence the Slack message when the nightly v0.34.x test is successful, now that it passes consistently.

Failures are still sent.

<!--

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

