### PR TITLE
Merge v0.34.23-alpha.agoric.4

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,9 +36,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v0.34.23-alpha.agoric.2]
+## [v0.34.23-alpha.agoric.3]
 
 * Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.
+
+## [v0.34.23-alpha.agoric.2]
+
+* Adapt to new callback tracking. See tendermint/tendermint#8331
 
 ## [v0.34.23-alpha.agoric.1]
 

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v0.34.23-alpha.agoric.4]
+
+* Lower default `BlockParams.MaxBytes` to 5MB to mitigate asa-2023-002 
+
 ## [v0.34.23-alpha.agoric.3]
 
 * Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v0.34.27-alpha.agoric.2]
+
+* Merge `tendermint/tendermint` v0.34.27.
+
 ## [v0.34.23-alpha.agoric.2]
 
 * Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v0.34.27-alpha.agoric.3]
+
+* Merge `agoric-labs/tendermint` v0.34.23-alpha.agoric.4.
+
 ## [v0.34.23-alpha.agoric.4]
 
 * Lower default `BlockParams.MaxBytes` to 5MB to mitigate asa-2023-002 

--- a/types/params.go
+++ b/types/params.go
@@ -34,7 +34,7 @@ func DefaultConsensusParams() *tmproto.ConsensusParams {
 // DefaultBlockParams returns a default BlockParams.
 func DefaultBlockParams() tmproto.BlockParams {
 	return tmproto.BlockParams{
-		MaxBytes:   22020096, // 21MB
+		MaxBytes:   5 * 1024 * 1024, // 5MB
 		MaxGas:     -1,
 		TimeIotaMs: 1000, // 1s
 	}


### PR DESCRIPTION
## Description

Merge `v0.34.23-alpha.agoric.4` which pulls in https://github.com/agoric-labs/tendermint/pull/36, a [mitigation](https://github.com/notional-labs/placid/blob/main/README.md#mitigations) for [asa-2023-002](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604).

Also fixes the Agoric specific changelog.

---

#### PR checklist

- [ ] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

