### PR TITLE
fix(rpc): make WebSocket handler quiet for normal close

### DIFF
--- a/rpc/jsonrpc/server/ws_handler.go
+++ b/rpc/jsonrpc/server/ws_handler.go
@@ -93,6 +93,10 @@ func (wm *WebsocketManager) WebsocketHandler(w http.ResponseWriter, r *http.Requ
 		wm.logger.Error("Failed to start connection", "err", err)
 		return
 	}
+	if !con.IsRunning() {
+		// Already stopped.
+		return
+	}
 	if err := con.Stop(); err != nil {
 		wm.logger.Error("error while stopping connection", "error", err)
 	}
@@ -440,7 +444,9 @@ func (wsc *wsConnection) writeRoutine() {
 				continue
 			}
 			if err = wsc.writeMessageWithDeadline(websocket.TextMessage, jsonBytes); err != nil {
-				wsc.Logger.Error("Failed to write response", "err", err, "msg", msg)
+				if err.Error() != "websocket: close sent" {
+					wsc.Logger.Error("Failed to write response", "err", err, "msg", msg)
+				}
 				return
 			}
 		}


### PR DESCRIPTION
## Description

Silence Error logs that are written even if the WebSocket is disconnected normally.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

