### PR TITLE
feat(p2p): avoid blocking ping/pong; feed msgs through a limited buffer to a separate goroutine

### DIFF
--- a/p2p/conn/connection_test.go
+++ b/p2p/conn/connection_test.go
@@ -618,6 +618,219 @@ func TestMConnectionChannelOverflow(t *testing.T) {
 
 }
 
+func TestMConnectionMaxChannelSize(t *testing.T) {
+	log.TestingLogger().Info("TestMConnectionSendMsgRecvQueueSize")
+	chOnErr := make(chan struct{})
+	chOnRcv := make(chan struct{})
+
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrorsWithQueueSize(t, chOnErr)
+	defer mconnClient.Stop() //nolint:errcheck // ignore for tests
+	defer mconnServer.Stop() //nolint:errcheck // ignore for tests
+
+	onReceiveDone := make(chan struct{})
+
+	mconnServer.onReceive = func(chID byte, msgBytes []byte) {
+		log.TestingLogger().Info(":- onReceive called")
+		<-onReceiveDone
+		chOnRcv <- struct{}{}
+	}
+
+	mconnServer._maxPacketMsgSize = mconnClient.config.MaxPacketMsgPayloadSize * 15
+	mconnServer.msgRecvQueue = make(chan ConnMsg)
+	client := mconnClient.conn
+	protoWriter := protoio.NewDelimitedWriter(client)
+
+	// send msg thats just right
+	var packet = tmp2p.PacketMsg{
+		ChannelID: 0x01,
+		EOF:       true,
+		Data:      make([]byte, mconnClient.config.MaxPacketMsgPayloadSize),
+	}
+	var err error
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.NoError(t, err)
+
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.NoError(t, err)
+
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.Error(t, err, "read/write on closed pipe")
+
+}
+
+func TestMConnectionMaxChannelSizeUnreached(t *testing.T) {
+	log.TestingLogger().Info("TestMConnectionSendMsgRecvQueueSize")
+	chOnErr := make(chan struct{})
+	chOnRcv := make(chan struct{})
+
+	mconnClient, mconnServer := newClientAndServerConnsForReadErrorsWithQueueSize(t, chOnErr)
+	defer mconnClient.Stop() //nolint:errcheck // ignore for tests
+	defer mconnServer.Stop() //nolint:errcheck // ignore for tests
+
+	onReceiveDone := make(chan struct{})
+
+	mconnServer.onReceive = func(chID byte, msgBytes []byte) {
+		log.TestingLogger().Info(":- onReceive called")
+		<-onReceiveDone
+		chOnRcv <- struct{}{}
+	}
+
+	mconnServer._maxPacketMsgSize = mconnClient.config.MaxPacketMsgPayloadSize * 15
+	mconnServer.msgRecvQueue = make(chan ConnMsg, 3)
+	client := mconnClient.conn
+	protoWriter := protoio.NewDelimitedWriter(client)
+
+	// send msg thats just right
+	var packet = tmp2p.PacketMsg{
+		ChannelID: 0x01,
+		EOF:       true,
+		Data:      make([]byte, mconnClient.config.MaxPacketMsgPayloadSize),
+	}
+	var err error
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.NoError(t, err)
+
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.NoError(t, err)
+
+	_, err = protoWriter.WriteMsg(mustWrapPacket(&packet))
+	require.NoError(t, err)
+
+}
+
+func newClientAndServerConnsForReadErrorsWithQueueSize(
+	t *testing.T,
+	chOnErr chan struct{}) (*MConnection, *MConnection) {
+	server, client := NetPipe()
+
+	onReceive := func(chID byte, msgBytes []byte) {}
+	onError := func(r interface{}) {}
+
+	// create client conn with two channels
+	chDescs := []*ChannelDescriptor{
+		{ID: 0x01, Priority: 1, SendQueueCapacity: 1},
+		{ID: 0x02, Priority: 1, SendQueueCapacity: 1},
+	}
+
+	mcConfig := DefaultMConnConfig()
+	mcConfig.MsgRecvQueueSize = 1
+	mconnClient := NewMConnection(client, chDescs, onReceive, onError)
+	mconnClient.SetLogger(log.TestingLogger().With("module", "client"))
+	err := mconnClient.Start()
+	require.Nil(t, err)
+
+	// create server conn with 1 channel
+	// it fires on chOnErr when there's an error
+	serverLogger := log.TestingLogger().With("module", "server")
+	onError = func(r interface{}) {
+		chOnErr <- struct{}{}
+	}
+	mconnServer := createMConnectionWithCallbacks(server, onReceive, onError)
+	mconnServer.SetLogger(serverLogger)
+	err = mconnServer.Start()
+	require.Nil(t, err)
+	return mconnClient, mconnServer
+}
+
+func TestMConnectionReceiveBufferAndCapacity(t *testing.T) {
+	msgs := [][]byte{[]byte("10000000"), []byte("20000000"), []byte("30000000")}
+
+	testCases := []struct {
+		name        string
+		isBuffer    bool
+		capacity    int
+		shouldBlock bool
+		messages    [][]byte
+	}{
+		{
+			name:        "happy path",
+			capacity:    10000,
+			isBuffer:    true,
+			messages:    msgs,
+			shouldBlock: false,
+		},
+		{
+			name:        "capacity is maxed",
+			isBuffer:    true,
+			capacity:    9,
+			messages:    msgs,
+			shouldBlock: true,
+		},
+		{
+			name:        "channel is maxed",
+			isBuffer:    false,
+			capacity:    2,
+			messages:    msgs,
+			shouldBlock: true,
+		},
+		{
+			name:        "channel happy path",
+			isBuffer:    false,
+			capacity:    10000,
+			messages:    msgs,
+			shouldBlock: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server, client := NetPipe()
+			defer server.Close()
+			defer client.Close()
+
+			receivedCh := make(chan []byte)
+			errorsCh := make(chan interface{})
+			onReceiveWork := make(chan struct{})
+			onReceive := func(chID byte, msgBytes []byte) {
+				<-onReceiveWork
+				receivedCh <- msgBytes
+			}
+			onError := func(r interface{}) {
+				errorsCh <- r
+			}
+			mconn1 := createMConnectionWithCallbacks(client, onReceive, onError)
+			if tc.isBuffer {
+				mconn1.config.RecvMessageCapacity = tc.capacity
+			} else {
+				mconn1.msgRecvQueue = make(chan ConnMsg, tc.capacity)
+			}
+			err := mconn1.Start()
+			require.Nil(t, err)
+			defer mconn1.Stop() //nolint:errcheck // ignore for tests
+
+			mconn2 := createTestMConnection(server)
+			err = mconn2.Start()
+			require.Nil(t, err)
+			defer mconn2.Stop() //nolint:errcheck // ignore for tests
+
+			msgs := tc.messages
+
+			for _, msg := range msgs {
+				assert.True(t, mconn2.Send(0x01, msg))
+			}
+		MSG_LOOP:
+			for _, msg := range msgs {
+				select {
+				case receivedBytes := <-receivedCh:
+					log.TestingLogger().Info(string(receivedBytes))
+					t.Fatalf("This should not have been reached")
+				case err := <-errorsCh:
+					if !tc.shouldBlock {
+						t.Fatalf("Expected %s, got %+v", msg, err)
+					}
+					break MSG_LOOP
+
+				case <-time.After(100 * time.Millisecond):
+					log.TestingLogger().Info("TestMConnectionReceive2 timeout")
+					onReceiveWork <- struct{}{}
+				}
+				receivedBytes := <-receivedCh
+				assert.Equal(t, msg, receivedBytes)
+			}
+		})
+	}
+}
+
 type stopper interface {
 	Stop() error
 }


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/10742

## Description

Add a new goroutine to handle messages read from the peer connection. This allows processing ping/pong messages even if reactors are blocked. To avoid unbounded growth the buffered channel between the recv and msg processing go routines is limited in depth of number of msgs, and in aggregate size of msgs.

This maintains the in order processing of messages over a p2p connection, but offloads all its processing, including protobuf parsing to the goroutine, and as such localizes the changed needed to the connection abstraction unlike other cometbft efforts (https://github.com/cometbft/cometbft/pull/3230, https://github.com/cometbft/cometbft/pull/3209). It's also compatible with efforts to parallelize some reactor processing that are ongoing (https://github.com/cometbft/cometbft/issues/2685, https://github.com/cometbft/cometbft/pull/3554)

## Scaling considerations 

Incorporates a "fix" for https://github.com/cometbft/cometbft/issues/3237 as we need to be able to keep receiving messages on a channel that has a message pending in the queue. This is done by simply reallocating a new buffer instead of truncating the working one. I believe this was a premature optimization of the tendermint code, golang has a pretty good memory allocator.

The aggregate size of the queue is bounded to the default max size of a message in a channel, but allowing a single message over that default size if the channel needs it. I believe this ensure a remote peer cannot consume significantly more memory than it could otherwise: it can only at most consume twice the max size of a message allowed by any channel.

## Testing

Tested manually on a follower running this branch as an out-of-process tendermint.

TODO: add unit tests for edge conditions
- Test with `MsgRecvQueueSize` at 0 (unbuffered channel). A single message received should be processed by the reactor immediately
- Test with 2 messages in combination putting the queue over the aggregate size limit: verify that the second message blocks until the first message is processed by the consuming routine
- Test that a single message of the aggregate size limit or larger can be processed
- Test that closing the connection with messages still pending on the queue doesn't log any panic
- Test that closing the connection with data remaining to be read from the raw connection doesn't log any panic (should be an existing test?)

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use
  [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

