### PR TITLE
fix(abci): do not assume `EventAttribute` is base64

### DIFF
--- a/abci/types/result.go
+++ b/abci/types/result.go
@@ -102,14 +102,39 @@ func (r *ResponseCommit) UnmarshalJSON(b []byte) error {
 	return jsonpbUnmarshaller.Unmarshal(reader, r)
 }
 
-func (r *EventAttribute) MarshalJSON() ([]byte, error) {
-	s, err := jsonpbMarshaller.MarshalToString(r)
-	return []byte(s), err
+func (r EventAttribute) MarshalJSONPB(marshaler *jsonpb.Marshaler) ([]byte, error) {
+	return r.MarshalJSON()
+}
+
+func (r *EventAttribute) UnmarshalJSONPB(unmarshaler *jsonpb.Unmarshaler, b []byte) error {
+	return r.UnmarshalJSON(b)
+}
+
+// stringyEventAttribute [AGORIC] avoids base64 encoding of the key and value
+// fields in the EventAttribute struct. This is necessary because the
+// EventAttribute struct is declared with byte slices, but code in the wild just
+// cast to and from strings, without any use of base64.
+type stringyEventAttribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (r EventAttribute) MarshalJSON() ([]byte, error) {
+	stringyAttr := stringyEventAttribute{
+		Key:   string(r.Key),
+		Value: string(r.Value),
+	}
+	return json.Marshal(stringyAttr)
 }
 
 func (r *EventAttribute) UnmarshalJSON(b []byte) error {
-	reader := bytes.NewBuffer(b)
-	return jsonpbUnmarshaller.Unmarshal(reader, r)
+	var stringyAttr stringyEventAttribute
+	if err := json.Unmarshal(b, &stringyAttr); err != nil {
+		return err
+	}
+	r.Key = []byte(stringyAttr.Key)
+	r.Value = []byte(stringyAttr.Value)
+	return nil
 }
 
 // Some compile time assertions to ensure we don't
@@ -122,6 +147,11 @@ type jsonRoundTripper interface {
 	json.Unmarshaler
 }
 
+type jsonpbRoundTripper interface {
+	jsonpb.JSONPBMarshaler
+	jsonpb.JSONPBUnmarshaler
+}
+
 var _ jsonRoundTripper = (*ResponseCommit)(nil)
 var _ jsonRoundTripper = (*ResponseQuery)(nil)
 var _ jsonRoundTripper = (*ResponseDeliverTx)(nil)
@@ -129,3 +159,5 @@ var _ jsonRoundTripper = (*ResponseCheckTx)(nil)
 var _ jsonRoundTripper = (*ResponseSetOption)(nil)
 
 var _ jsonRoundTripper = (*EventAttribute)(nil)
+var _ jsonpbRoundTripper = (*EventAttribute)(nil)
+var _ jsonpb.JSONPBMarshaler = EventAttribute{}


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

refs: Agoric/agoric-sdk#11257

`EventAttributes` are currently a `Key []byte` and `Value []byte`, but by convention, they are not base64-encoded, just casted to and from strings.

They should be JSON-serialised as strings for consistency and to interoperate with `simd query txs`.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

